### PR TITLE
ET-737: removed harbor login as it doesn't push to harbor during this stage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,6 @@ runs:
         shell: bash
         run: |
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
-          docker login -u $HARBOR_USERNAME -p $HARBOR_CLI_SECRET $HARBOR
           docker build --build-arg MODULE=$MODULE --build-arg VERSION=$VERSION --build-arg SHORTENED_VERSION=$SHORTENED_VERSION --build-arg CUTPATH=$MODULE -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD -t $ACR/$ENGINEERING_PREFIX/$MODULE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE:$TAG
         env:


### PR DESCRIPTION
Removed harbor login as this step only pushes to ACR and is not necessary. 