### PR TITLE
ET-734: platform: Module Lowercase Variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,9 +141,14 @@ runs:
       - name: build and push image (default context)
         shell: bash
         run: |
+          # Convert module name to lowercase for image naming (Docker requirement)
+          MODULE_LOWERCASE=$(echo "$MODULE" | tr '[:upper:]' '[:lower:]')
+          echo "Original module name: $MODULE"
+          echo "Lowercase module name for image: $MODULE_LOWERCASE"
+          
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
-          docker build --build-arg MODULE=$MODULE --build-arg VERSION=$VERSION --build-arg SHORTENED_VERSION=$SHORTENED_VERSION --build-arg CUTPATH=$MODULE -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD -t $ACR/$ENGINEERING_PREFIX/$MODULE:$TAG
-          docker push $ACR/$ENGINEERING_PREFIX/$MODULE:$TAG
+          docker build --build-arg MODULE=$MODULE --build-arg VERSION=$VERSION --build-arg SHORTENED_VERSION=$SHORTENED_VERSION --build-arg CUTPATH=$MODULE -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
+          docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
         env:
           VERSION: ${{ inputs.version }}
           SHORTENED_VERSION: ${{ inputs.shortened_version }}

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,7 @@ runs:
           SHORTENED_VERSION: ${{ inputs.shortened_version }}
           TAG: ${{ inputs.tag }}
           MODULE: ${{ inputs.module }}
+          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}          
           CONTEXT_BUILD: ${{ inputs.docker_context }}
           DOCKERFILE: ${{ inputs.dockerfile_path }} 
           GITHUB_WORKSPACE: ${{ github.workspace }}

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Module to build (product, devdb, editions)'
     required: true
     type: string
+  module_lowercase:
+    description: 'Module name in lowercase to comply with Docker image naming requirements'
+    required: true
+    type: string
   dockerfile_path:
     description: 'Path to the dockerfile for this specific image build (injector, platform w/ module, editions)'
     required: true
@@ -141,11 +145,6 @@ runs:
       - name: build and push image (default context)
         shell: bash
         run: |
-          # Convert module name to lowercase for image naming (Docker requirement)
-          MODULE_LOWERCASE=$(echo "$MODULE" | tr '[:upper:]' '[:lower:]')
-          echo "Original module name: $MODULE"
-          echo "Lowercase module name for image: $MODULE_LOWERCASE"
-          
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
           docker build --build-arg MODULE=$MODULE --build-arg VERSION=$VERSION --build-arg SHORTENED_VERSION=$SHORTENED_VERSION --build-arg CUTPATH=$MODULE -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
@@ -155,7 +154,7 @@ runs:
           TAG: ${{ inputs.tag }}
           MODULE: ${{ inputs.module }}
           CONTEXT_BUILD: ${{ inputs.docker_context }}
-          DOCKERFILE: ${{ inputs.dockerfile_path }}
+          DOCKERFILE: ${{ inputs.dockerfile_path }} 
           GITHUB_WORKSPACE: ${{ github.workspace }}
           HARBOR: ${{ inputs.harbor }}
           HARBOR_CLI_SECRET: ${{ inputs.harbor_cli_secret }}

--- a/action.yml
+++ b/action.yml
@@ -81,8 +81,8 @@ runs:
         shell: bash
         run: |
             echo "Copying language packs from utils-language-packs"
-            mkdir $GITHUB_WORKSPACE/$MODULE/$SHORTENED_VERSION
-            mkdir $GITHUB_WORKSPACE/$MODULE/$SHORTENED_VERSION/languagepacks
+            mkdir -p $GITHUB_WORKSPACE/$MODULE/$SHORTENED_VERSION
+            mkdir -p $GITHUB_WORKSPACE/$MODULE/$SHORTENED_VERSION/languagepacks
             pwd
             ls -la
             ls -la utils-language-packs


### PR DESCRIPTION
I had to introduce a new module_lowercase variable as the platform workflow for the 5 injector dependancies uses this reusable push action.

The embeddedExamples module has an uppercase E and it was failing the docker build by using the standard "module" variable.