### PR TITLE
Inputs: add flag to control when to download binaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Which OS arch to build this image on (amd64, arm64)'
     required: true
     type: string
+  download_binaries:
+    description: 'Does this build require binaries to be downloaded'
+    default: 'true'
+    type: boolean
   module:
     description: 'Module to build (product, devdb, editions)'
     required: true
@@ -129,7 +133,7 @@ runs:
         uses: docker/setup-buildx-action@v3
 
       - name: Download binaries for injector builds (skips modules editions)
-        if: "!contains(inputs.module, 'editions')"
+        if: ${{ inputs.download_binaries == 'true' }}
         uses: actions/download-artifact@v4
         with:
             name: binaries


### PR DESCRIPTION
Also see: https://github.com/IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/pull/6

Previously we had an edge case hard coded for editions.  This explicit input will be clear

The default value means existing workflows do not need to be changes, except for the SaaS builds which are already broken.


Successful run: https://github.com/IQGeo/editions-wfm-telecom/actions/runs/22637629645