### PR TITLE
ET-778: centralized injector modifications

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,9 +70,6 @@ inputs:
     description: 'Engineering prefix to place multi arch images in Harbor'
     type: string
     default: devops_sandbox_engineering
-  base_image:
-    description: 'Base image for centralized Dockerfile.injector'
-    required: false
 
 runs:
     using: "composite"
@@ -177,7 +174,6 @@ runs:
             --build-arg VERSION=$VERSION \
             --build-arg SHORTENED_VERSION=$SHORTENED_VERSION \
             --build-arg CUTPATH=$MODULE \
-            --build-arg BASE_IMAGE=$BASE_IMAGE \
             -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD \
             -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
@@ -197,4 +193,3 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          BASE_IMAGE: ${{ inputs.base_image }}

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
     description: 'Engineering prefix to place multi arch images in Harbor'
     type: string
     default: devops_sandbox_engineering
+  base_image:
+    description: 'Base image for centralized Dockerfile.injector'
+    required: false
 
 runs:
     using: "composite"
@@ -167,6 +170,7 @@ runs:
             --build-arg VERSION=$VERSION \
             --build-arg SHORTENED_VERSION=$SHORTENED_VERSION \
             --build-arg CUTPATH=$MODULE \
+            --build-arg BASE_IMAGE=$BASE_IMAGE \
             -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD \
             -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
@@ -186,3 +190,4 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          BASE_IMAGE: ${{ inputs.base_image }}

--- a/action.yml
+++ b/action.yml
@@ -70,9 +70,6 @@ inputs:
     description: 'Engineering prefix to place multi arch images in Harbor'
     type: string
     default: devops_sandbox_engineering
-  base_image:
-    description: 'Base image for centralized Dockerfile.injector'
-    required: false
 
 runs:
     using: "composite"
@@ -170,7 +167,6 @@ runs:
             --build-arg VERSION=$VERSION \
             --build-arg SHORTENED_VERSION=$SHORTENED_VERSION \
             --build-arg CUTPATH=$MODULE \
-            --build-arg BASE_IMAGE=$BASE_IMAGE \
             -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD \
             -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
@@ -190,4 +186,3 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          BASE_IMAGE: ${{ inputs.base_image }}

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
     description: 'Engineering prefix to place multi arch images in Harbor'
     type: string
     default: devops_sandbox_engineering
+  base_image:
+    description: 'Base image for centralized Dockerfile.injector'
+    required: false
 
 runs:
     using: "composite"
@@ -174,6 +177,7 @@ runs:
             --build-arg VERSION=$VERSION \
             --build-arg SHORTENED_VERSION=$SHORTENED_VERSION \
             --build-arg CUTPATH=$MODULE \
+            --build-arg BASE_IMAGE=$BASE_IMAGE \
             -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD \
             -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
           docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
@@ -193,3 +197,4 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          BASE_IMAGE: ${{ inputs.base_image }}

--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,13 @@ runs:
           MODULE: ${{ inputs.module }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
+      - name: Download Dockerfile.injector
+        if: ${{ inputs.download_binaries == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: injector-dockerfile
+          path: ${{ github.workspace }}
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Adding base image as a usable parameter for the centralized Dockerfile location task.

This is a three part solution coupled with https://github.com/IQGeo/devops-engineering-ci-public-build-platform-workflow/tree/devops/ET-778-centralized-injectors-modifications and https://github.com/IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/tree/devops/ET-778-centralized-injectors-modifications