### PR TITLE
et-778: gha: reverting change as it messed up nro builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,12 +139,12 @@ runs:
           MODULE: ${{ inputs.module }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      - name: Download Dockerfile.injector
-        if: ${{ inputs.download_binaries == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: injector-dockerfile
-          path: ${{ github.workspace }}
+      # - name: Download Dockerfile.injector
+      #   if: ${{ inputs.download_binaries == 'true' }}
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: injector-dockerfile
+      #     path: ${{ github.workspace }}
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Reverting change as it was causing error: 

build-all / build-injectors (network_revenue_optimizer) / build-arm64-image
Unable to download artifact(s): Artifact not found for name: injector-dockerfile
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md