### PR TITLE
ET-778: centralized injectors modifications

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,12 +139,12 @@ runs:
           MODULE: ${{ inputs.module }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      # - name: Download Dockerfile.injector
-      #   if: ${{ inputs.download_binaries == 'true' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: injector-dockerfile
-      #     path: ${{ github.workspace }}
+      - name: Download Dockerfile.injector
+        if: ${{ inputs.download_binaries == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: injector-dockerfile
+            path: ${{ github.workspace }}
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The modifications for the build push action only include the artifact download for the centralized dockerfiles.

It's a two step process now -> build module is responsible for the checkout + upload of the artifact, this action is responsible for downloading it.  