### PR TITLE
ET-979: Add SBOM/Attestation Steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,6 @@ runs:
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
           docker buildx build \
             --provenance=true \
-            --sbom=true \
             --push \
             --metadata-file /tmp/build-metadata.json \
             --build-arg MODULE=$MODULE \
@@ -218,6 +217,34 @@ runs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate SBOM from image layers
+        shell: bash
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}
+        run: |
+          syft "registry:${ACR}/${ENGINEERING_PREFIX}/${MODULE_LOWERCASE}@${DIGEST}" \
+            --output spdx-json \
+            > /tmp/sbom.spdx.json
+
+      - name: Attach SBOM attestation with cosign
+        shell: bash
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}
+        run: |
+          cosign attest --yes \
+            --predicate /tmp/sbom.spdx.json \
+            --type spdxjson \
+            "${ACR}/${ENGINEERING_PREFIX}/${MODULE_LOWERCASE}@${DIGEST}"
 
       - name: Sign image with cosign keyless
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -183,6 +183,7 @@ runs:
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
           docker buildx build \
             --provenance=true \
+            --sbom=true \
             --push \
             --metadata-file /tmp/build-metadata.json \
             --build-arg MODULE=$MODULE \
@@ -217,34 +218,6 @@ runs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
-
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
-
-      - name: Generate SBOM from image layers
-        shell: bash
-        env:
-          DIGEST: ${{ steps.digest.outputs.value }}
-          ACR: ${{ inputs.acr }}
-          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}
-        run: |
-          syft "registry:${ACR}/${ENGINEERING_PREFIX}/${MODULE_LOWERCASE}@${DIGEST}" \
-            --output spdx-json \
-            > /tmp/sbom.spdx.json
-
-      - name: Attach SBOM attestation with cosign
-        shell: bash
-        env:
-          DIGEST: ${{ steps.digest.outputs.value }}
-          ACR: ${{ inputs.acr }}
-          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}
-        run: |
-          cosign attest --yes \
-            --predicate /tmp/sbom.spdx.json \
-            --type spdxjson \
-            "${ACR}/${ENGINEERING_PREFIX}/${MODULE_LOWERCASE}@${DIGEST}"
 
       - name: Sign image with cosign keyless
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -216,9 +216,16 @@ runs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/build-metadata.json)
           echo "value=$DIGEST" >> $GITHUB_OUTPUT
 
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ inputs.acr }}/${{ inputs.engineering_prefix }}/${{ inputs.module_lowercase }}
-          subject-digest: ${{ steps.digest.outputs.value }}
-          push-to-registry: true
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign keyless
+        shell: bash
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE_LOWERCASE: ${{ inputs.module_lowercase }}
+        run: |
+          cosign sign --yes \
+            "${ACR}/${ENGINEERING_PREFIX}/${MODULE_LOWERCASE}@${DIGEST}"

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,10 @@ inputs:
     description: 'Engineering prefix to place multi arch images in Harbor'
     type: string
     default: devops_sandbox_engineering
+  sbom_generator:
+    description: 'Shared BuildKit SBOM generator image (directory-mode syft scan so lockfile packages are included). Module- and version-agnostic; lives at a fixed path, not under engineering_prefix.'
+    type: string
+    default: iqgeoproddev.azurecr.io/engineering/sbom-generator:1
 
 runs:
     using: "composite"
@@ -183,7 +187,7 @@ runs:
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
           docker buildx build \
             --provenance=true \
-            --sbom=true \
+            --sbom=generator=$SBOM_GENERATOR \
             --push \
             --metadata-file /tmp/build-metadata.json \
             --build-arg MODULE=$MODULE \
@@ -208,6 +212,7 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          SBOM_GENERATOR: ${{ inputs.sbom_generator }}
 
       - name: Extract image digest
         id: digest

--- a/action.yml
+++ b/action.yml
@@ -177,19 +177,21 @@ runs:
           VERSION: ${{ inputs.version }}    
 
       - name: build and push image (default context)
+        id: build
         shell: bash
         run: |
           docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASWORD $ACR
-          docker build \
-            --provenance=false \
-            --sbom=false \
+          docker buildx build \
+            --provenance=true \
+            --sbom=true \
+            --push \
+            --metadata-file /tmp/build-metadata.json \
             --build-arg MODULE=$MODULE \
             --build-arg VERSION=$VERSION \
             --build-arg SHORTENED_VERSION=$SHORTENED_VERSION \
             --build-arg CUTPATH=$MODULE \
             -f $GITHUB_WORKSPACE/$DOCKERFILE $CONTEXT_BUILD \
             -t $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
-          docker push $ACR/$ENGINEERING_PREFIX/$MODULE_LOWERCASE:$TAG
         env:
           VERSION: ${{ inputs.version }}
           SHORTENED_VERSION: ${{ inputs.shortened_version }}
@@ -206,3 +208,17 @@ runs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
           REGISTRY_PASWORD: ${{ inputs.registry_password}}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+
+      - name: Extract image digest
+        id: digest
+        shell: bash
+        run: |
+          DIGEST=$(jq -r '."containerimage.digest"' /tmp/build-metadata.json)
+          echo "value=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ inputs.acr }}/${{ inputs.engineering_prefix }}/${{ inputs.module_lowercase }}
+          subject-digest: ${{ steps.digest.outputs.value }}
+          push-to-registry: true


### PR DESCRIPTION
Successful run:

https://github.com/IQGeo/product-network-manager-electric/actions/runs/29825322298

Updated workflow with manifest/sbom step. 
Confirmed that they are present and added results to the ET-979 jira ticket. 

Related PR's:

https://github.com/IQGeo/devops-engineering-ci-public-build-module-workflow/pull/15
https://github.com/IQGeo/devops-engineering-ci-public-multi-arch-action/pull/7